### PR TITLE
docker: Set interface link up

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -12,7 +12,7 @@ build:
         - ${SHIPPABLE_BUILD_DIR}/ccache
     pre_ci_boot:
         image_name: zephyrprojectrtos/ci
-        image_tag: master.27
+        image_tag: v0.9.1
         pull: true
         options: "-e HOME=/home/buildslave --privileged=true --tty --net=bridge --user buildslave"
 

--- a/README.docker
+++ b/README.docker
@@ -1,0 +1,54 @@
+# Testing with net-tools and Docker
+
+* Create Docker image
+
+	cd docker/
+	docker build -t net-tools .
+
+* Setup network interfaces, IP addresses and routes
+
+	./net-setup.sh --config docker.conf
+
+* Run Docker image
+
+  Set the docker internal network name to the value $DOCKER_USER_INTERFACE
+  in docker.config above, default is 'net-tools0'. The bridge network that
+  docker creates will be printed on standard out, it's bridge interface
+  name will be br-XXXXXXXXXXXX. Check that the IPv4 and IPv6 addresses
+  given on the docker command line match the subnets in 'docker.conf'.
+
+  Interactively:
+
+	docker run --hostname=zephyr --name=net-tools \
+	       --ip=192.0.2.2 --ip6=2001:db8::2 \
+	       --rm -it --network=net-tools0 net-tools sh
+
+        exit with Ctrl-p ctrl-q to execute tests from the command line
+
+  Non-interactively
+
+	docker run --hostname=zephyr --name=net-tools \
+	       --ip=192.0.2.2 --ip6=2001:db8::2 \
+	       --rm -dt --network=net-tools0 net-tools sh
+
+* Run Qemu / native-posix image
+
+	rm -rf build && mkdir build
+
+	cmake -GNinja -DBOARD=native_posix -B build
+	   or
+	cmake -GNinja -DBOARD=qemu_x86 -DOVERLAY_CONFIG=overlay-e1000.conf \
+	   -B build
+
+	ninja -C build run
+
+* Execute tests like echo-client
+
+	docker container exec net-tools /net-tools/echo-client 2001:db8::1
+	docker container exec net-tools /net-tools/echo-client -t 2001:db8::1
+	docker container exec net-tools /net-tools/echo-client 192.0.2.1
+	docker container exec net-tools /net-tools/echo-client -t 192.0.2.1
+
+* Remove the 'net-tools0' docker network:
+
+	docker network rm net-tools0

--- a/docker.conf
+++ b/docker.conf
@@ -1,0 +1,29 @@
+# Configuration file for setting IP addresses for a network interface.
+
+INTERFACE="$1"
+DOCKER_USER_INTERFACE=net-tools0
+
+HWADDR="00:00:5e:00:53:ff"
+
+IPV6_ADDR_1="2001:db8::254"
+IPV6_ROUTE_1="2001:db8::/64"
+
+IPV4_ADDR_1="192.0.2.254"
+IPV4_ROUTE_1="192.0.2.0/24"
+
+DOCKER_INTERFACE=$( docker network create \
+		    --subnet $IPV4_ROUTE_1 \
+		    --gateway $IPV4_ADDR_1 \
+		    --ipv6=true \
+		    --subnet $IPV6_ROUTE_1 \
+		    --gateway $IPV6_ADDR_1 \
+		    $DOCKER_USER_INTERFACE )
+DOCKER_INTERFACE="br-$(echo $DOCKER_INTERFACE | cut -c -12)"
+
+ip link set dev $INTERFACE address $HWADDR
+
+brctl addif $DOCKER_INTERFACE $INTERFACE
+
+ip link set dev $INTERFACE up
+
+echo $DOCKER_INTERFACE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+# Create Docker image that can be used for testing Zephyr network
+# sample applications.
+
+FROM fedora
+FROM gcc
+
+# RUN http_proxy=... git clone...
+RUN git clone http://github.com/zephyrproject-rtos/net-tools.git && \
+    make /net-tools/tunslip6 && make /net-tools/echo-client && \
+    make /net-tools/echo-server && make /net-tools/throughput-client
+
+WORKDIR /net-tools
+
+# We do not run any command automatically but let the test script run
+# the proper test application script.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,10 @@ FROM gcc
 
 # RUN http_proxy=... git clone...
 RUN git clone http://github.com/zephyrproject-rtos/net-tools.git && \
-    make /net-tools/tunslip6 && make /net-tools/echo-client && \
-    make /net-tools/echo-server && make /net-tools/throughput-client
+    cd /net-tools && \
+    make tunslip6 && make echo-client && \
+    make echo-server && make throughput-client && \
+    make coap-client
 
 WORKDIR /net-tools
 

--- a/echo-client.c
+++ b/echo-client.c
@@ -409,7 +409,7 @@ static int timeval_diff(struct timeval *start,
 
 	result->tv_sec = start->tv_sec - end->tv_sec;
 
-	if ((result->tv_usec = (start->tv_usec - end->tv_usec)) < 0) {
+	if ((result->tv_usec = (end->tv_usec - start->tv_usec)) < 0) {
 		result->tv_usec += 1000000;
 		result->tv_sec--;
 	}
@@ -733,14 +733,20 @@ again:
 
 out:
 	if (count_time > 0) {
+		unsigned long long time_spent;
+
 		if (do_exit) {
 			printf("\n");
 		}
 
-		printf("Average round trip %lld ms\n",
-		       (unsigned long long)((((double)sum_time /
-					      (double)count_time)) /
-					    1000.0));
+		time_spent = (unsigned long long)(((double)sum_time /
+						   (double)count_time));
+		if ((time_spent / 1000) == 0) {
+			printf("Average round trip %lld us\n", time_spent);
+		} else {
+			printf("Average round trip %lld ms\n",
+			       time_spent / 1000);
+		}
 	}
 
 	close(fd);

--- a/echo-client.c
+++ b/echo-client.c
@@ -267,7 +267,6 @@ static struct {
 	ENTRY_OK(lorem_ipsum),
 	ENTRY_OK(null_byte),
 	ENTRY_OK(array_256),
-	ENTRY_FAIL(array_1280), /* too long message will be discarded */
 
 	{ 0, 0 }
 };
@@ -640,8 +639,14 @@ again:
 
 			FD_ZERO(&rfds);
 			FD_SET(fd, &rfds);
-			tv.tv_sec = MAX_TIMEOUT;
-			tv.tv_usec = 0;
+
+			if (data[i].expecting_reply) {
+				tv.tv_sec = MAX_TIMEOUT;
+				tv.tv_usec = 0;
+			} else {
+				tv.tv_sec = 0;
+				tv.tv_usec = 0;
+			}
 
 			ret = select(fd + 1, &rfds, NULL, NULL, &tv);
 			if (ret < 0) {

--- a/libcoap/examples/etsi_coaptest.sh
+++ b/libcoap/examples/etsi_coaptest.sh
@@ -36,6 +36,7 @@ testgroups=( CORE LINK BLOCK OBS )
 testnumber=-1
 group=''
 
+cd "$(dirname $0)"
 source etsi_testcases.sh
 
 function usage {

--- a/zeth.conf
+++ b/zeth.conf
@@ -14,7 +14,7 @@ ip link set dev $INTERFACE up
 
 ip link set dev $INTERFACE address $HWADDR
 
-ip -6 address add $IPV6_ADDR_1 dev $INTERFACE
+ip -6 address add $IPV6_ADDR_1 dev $INTERFACE nodad
 ip -6 route add $IPV6_ROUTE_1 dev $INTERFACE
 ip address add $IPV4_ADDR_1 dev $INTERFACE
 ip route add $IPV4_ROUTE_1 dev $INTERFACE

--- a/zeth.conf
+++ b/zeth.conf
@@ -17,4 +17,4 @@ ip link set dev $INTERFACE address $HWADDR
 ip -6 address add $IPV6_ADDR_1 dev $INTERFACE nodad
 ip -6 route add $IPV6_ROUTE_1 dev $INTERFACE
 ip address add $IPV4_ADDR_1 dev $INTERFACE
-ip route add $IPV4_ROUTE_1 dev $INTERFACE
+ip route add $IPV4_ROUTE_1 dev $INTERFACE > /dev/null 2>&1


### PR DESCRIPTION
Depending on whether the interface link has already been created or
if it is created by this script, the link state can be either up or
down. Ensure the link is up by setting it in this script.

Signed-off-by: Patrik Flykt <patrik.flykt@linux.intel.com>